### PR TITLE
Move to tlog witnessing

### DIFF
--- a/.github/workflows/cosign.yml
+++ b/.github/workflows/cosign.yml
@@ -14,7 +14,10 @@ jobs:
       group: cosign-${{ github.event.issue.title }}
       cancel-in-progress: false
     steps:
-      - uses: project-oak/git-ratchet/actions/cosign@v0.1.7
+      # Pinned to a commit: this witness runs the origin project's code, so
+      # which revision it runs is a decision to make deliberately rather than
+      # inherit from whatever that project's main branch says today.
+      - uses: BenBirt/git-ratchet/actions/cosign@6ade309f7d180e23274e701bf585f788a0ba5339
         with:
           witness-key: ${{ secrets.WITNESS_SIGNING_KEY }}
 

--- a/.github/workflows/cosign.yml
+++ b/.github/workflows/cosign.yml
@@ -14,9 +14,6 @@ jobs:
       group: cosign-${{ github.event.issue.title }}
       cancel-in-progress: false
     steps:
-      # Pinned to a commit: this witness runs the origin project's code, so
-      # which revision it runs is a decision to make deliberately rather than
-      # inherit from whatever that project's main branch says today.
       - uses: project-oak/git-ratchet/actions/cosign@ef61689a3df70e2d443b18ac56288931178c8ce7
         with:
           witness-key: ${{ secrets.WITNESS_SIGNING_KEY }}

--- a/.github/workflows/cosign.yml
+++ b/.github/workflows/cosign.yml
@@ -17,7 +17,7 @@ jobs:
       # Pinned to a commit: this witness runs the origin project's code, so
       # which revision it runs is a decision to make deliberately rather than
       # inherit from whatever that project's main branch says today.
-      - uses: BenBirt/git-ratchet/actions/cosign@6ade309f7d180e23274e701bf585f788a0ba5339
+      - uses: project-oak/git-ratchet/actions/cosign@ef61689a3df70e2d443b18ac56288931178c8ce7
         with:
           witness-key: ${{ secrets.WITNESS_SIGNING_KEY }}
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It speaks the C2SP [tlog-witness](https://c2sp.org/tlog-witness) protocol. What 
 ## How it works
 
 1. A monitored repository publishes a new checkpoint by opening an issue here, titled `checkpoint: <origin>`, with the `add-checkpoint` request in a fenced `http` block.
-2. The [workflow](.github/workflows/cosign.yml) runs [`actions/cosign`](https://github.com/BenBirt/git-ratchet/tree/main/actions/cosign), which checks the origin is registered, answers the request, and commits the resulting state.
+2. The [workflow](.github/workflows/cosign.yml) runs [`actions/cosign`](https://github.com/project-oak/git-ratchet/tree/main/actions/cosign), which checks the origin is registered, answers the request, and commits the resulting state.
 3. The response is posted as a comment — whatever its status, since a refusal is an answer the origin needs to read — and the issue is closed.
 
 Both messages are HTTP messages serialised as `message/http` ([RFC 9112](https://www.rfc-editor.org/rfc/rfc9112.html)), so the exchange in each issue reads as the HTTP request and response it stands for.

--- a/README.md
+++ b/README.md
@@ -8,25 +8,40 @@ This repository operates as a **transparency log witness** — it cosigns checkp
 
 Witnesses play a critical role in preventing **split-view attacks**, where a log operator might present different versions of history to different users. By independently verifying and cosigning checkpoints, this witness provides assurance that the observed log state is globally consistent.
 
+It speaks the C2SP [tlog-witness](https://c2sp.org/tlog-witness) protocol. What is unusual is only the wire: an issue carries the request and a comment carries the response, in place of a POST and its reply. A witness reached this way answers exactly as an HTTP one would, because it runs the same [transparency-dev/witness](https://github.com/transparency-dev/witness) handler behind that transport.
+
 ## How it works
 
-1. A monitored repository (e.g. `project-oak/git-ratchet`) publishes a new checkpoint by opening an issue on this repository with the title prefix `checkpoint:`.
-2. A [GitHub Actions workflow](.github/workflows/cosign.yml) is triggered, which uses the [`project-oak/git-ratchet/actions/cosign`](https://github.com/project-oak/git-ratchet/tree/main/actions/cosign) action to verify and cosign the checkpoint.
-3. The cosigned checkpoint is committed to the [`checkpoints/`](checkpoints/) directory, recording the witnessed state of the monitored repository's ref.
+1. A monitored repository publishes a new checkpoint by opening an issue here, titled `checkpoint: <origin>`, with the `add-checkpoint` request in a fenced `http` block.
+2. The [workflow](.github/workflows/cosign.yml) runs [`actions/cosign`](https://github.com/BenBirt/git-ratchet/tree/main/actions/cosign), which checks the origin is registered, answers the request, and commits the resulting state.
+3. The response is posted as a comment — whatever its status, since a refusal is an answer the origin needs to read — and the issue is closed.
+
+Both messages are HTTP messages serialised as `message/http` ([RFC 9112](https://www.rfc-editor.org/rfc/rfc9112.html)), so the exchange in each issue reads as the HTTP request and response it stands for.
 
 ## Repository structure
 
 ```
 ├── .github/workflows/
-│   └── cosign.yml            # GitHub Actions workflow for cosigning checkpoints
+│   └── cosign.yml     # Cosigns checkpoints submitted as issues
+├── origins/
+│   └── <origin>       # Verifier keys for a registered origin, one per line
 └── checkpoints/
-    └── github.com/
-        └── <org>/<repo>/
-            ├── vkeys.txt     # Verification keys for the monitored repository
-            └── refs/
-                ├── heads/    # Cosigned branch checkpoints
-                └── tags/     # Cosigned tag checkpoints
+    └── <origin>       # The last checkpoint cosigned for that origin's log
 ```
+
+`<origin>` is the log's origin identifier, so a witness for a log named
+`github.com/example/repo` has `origins/github.com/example/repo` and
+`checkpoints/github.com/example/repo`. The intermediate directories come from
+the origin's own name.
+
+There is one log per monitored repository, so there is one state file per
+origin: the ratchet is over the log's tree size, not over any one ref.
+
+## Registering an origin
+
+An origin is registered by adding its verifier keys, one per line, at
+`origins/<origin>`. Lines beginning with `#` are comments. A request from an
+unregistered origin is answered `404 Not Found` and no state is written.
 
 ## Verification
 
@@ -36,10 +51,7 @@ The public verification key for this witness is:
 github.com/BenBirt/git-witness+ca289127+BNn4Sjn2yt3uHK8N7nFgWtZccQoei3GAxWJjZN9Uc3tv
 ```
 
-Each checkpoint file in `checkpoints/` contains:
-- The repository and ref being witnessed
-- The commit hash at the time of witnessing
-- Signatures from both the origin repository and this witness
+Each file in `checkpoints/` is a cosigned [tlog-checkpoint](https://c2sp.org/tlog-checkpoint): the log's origin, its tree size, its root hash, and signatures from both the log and this witness.
 
 ## License
 

--- a/checkpoints/github.com/project-oak/git-ratchet/refs/heads/main
+++ b/checkpoints/github.com/project-oak/git-ratchet/refs/heads/main
@@ -1,4 +1,0 @@
-github.com/project-oak/git-ratchet refs/heads/main
-47c6d201e63e336bc1e617b01fd4a23a4d9f93f4
-
-— github.com/project-oak/git-ratchet OfIP9TacSo2Vt7gWuBu3zmp956OsEp8qacl5hn+U1Ic8ccZS2+OacZwHRezTfo77H9coyoh8dfOQtapFuzP3IinNXwc=— github.com/BenBirt/git-witness yiiRJwAAAABqZ3eHeXFstQLoOVCHVfNosPabE2gpDXUsa9vIiFgHuY8ffvmoGor77zEv7aobVN2ZvryEhIz+IczgE8B7NVPpFO7sAg==

--- a/checkpoints/github.com/project-oak/git-ratchet/refs/tags/v0.1.4
+++ b/checkpoints/github.com/project-oak/git-ratchet/refs/tags/v0.1.4
@@ -1,4 +1,0 @@
-github.com/project-oak/git-ratchet refs/tags/v0.1.4
-6bfbd1c48b082042908a579ed6ee5f8a7bbdf985
-
-— github.com/project-oak/git-ratchet OfIP9Z6/0Dxo213Th19vCk3zZWMFie49qL/HfM3vi45PczWnJX/MjqDXDIZV+qCSOKJckf0+OR9Ky6ZD2xt56vM4bQA=— github.com/BenBirt/git-witness yiiRJwAAAABqRjri8WXG67vIP32kXvDousf2Wcx5euimiVOeY3nFwQkSiNKpXmbvH1y3PxrSAUhE7RUQwXj3nlGMS8PRoMzHOT1KAQ==

--- a/checkpoints/github.com/project-oak/git-ratchet/refs/tags/v0.1.5
+++ b/checkpoints/github.com/project-oak/git-ratchet/refs/tags/v0.1.5
@@ -1,4 +1,0 @@
-github.com/project-oak/git-ratchet refs/tags/v0.1.5
-bfb6fe200acfb6295a0edb6f2b996310a6f0f703
-
-— github.com/project-oak/git-ratchet OfIP9cw9vGXFXMLCy6X8M/SdPJuYNT7KhAKcYReXPXBterxyItxhZSxZYOCNP6GKlOc0nZOeKuoX5QaMwX+o0vA2/w0=— github.com/BenBirt/git-witness yiiRJwAAAABqRkbSgrf5UCFxKeuTBQVXI1vTVJy0QjIIpel5lZ7sQXD+DTRjE05TtjjFZA2+/ztIj/yMSmgHSCSEFLnb0PZljhTrAQ==

--- a/checkpoints/github.com/project-oak/git-ratchet/refs/tags/v0.1.6
+++ b/checkpoints/github.com/project-oak/git-ratchet/refs/tags/v0.1.6
@@ -1,4 +1,0 @@
-github.com/project-oak/git-ratchet refs/tags/v0.1.6
-1bffde33e54f6d17232dc3e3c1916afedca2262d
-
-— github.com/project-oak/git-ratchet OfIP9aEAYu+25NYF1mInkAl1ndeDRirPrbqxOeNKsMmnap7BZi7s0AKPXqk5hDr9HQo85XTKO5f32F9EbgZt7I4A/Aw=— github.com/BenBirt/git-witness yiiRJwAAAABqRkffeHxMUO4ywlzqJPHN/mBaFjn4h+GtuaAMiR2Wv9W1qHvxdY+0gkxruXXt2KTsPtnuU9F9j0I3CdlCVyMws0CuDQ==

--- a/checkpoints/github.com/project-oak/git-ratchet/refs/tags/v0.1.7
+++ b/checkpoints/github.com/project-oak/git-ratchet/refs/tags/v0.1.7
@@ -1,4 +1,0 @@
-github.com/project-oak/git-ratchet refs/tags/v0.1.7
-9398ac45a85cde86b26eb9ba4069b062285e5ed6
-
-— github.com/project-oak/git-ratchet OfIP9VaeKCXZUhjtgvXlec0yPZ6qjQXnhYBzADJvRNHAZpPkBLfc+FI9Ge+hHmH+Y8/PZI8kucCULAobI/c0GuNkQwI=— github.com/BenBirt/git-witness yiiRJwAAAABqR2LGulPmAxlKKlqOnYIKsDGKN7gDzOjTVpr5Yom7GWeX6YGHzumM2/iVwZuj0ImZsCnSIt0cFb92bTBpGwZIlH+tAQ==

--- a/checkpoints/github.com/project-oak/git-ratchet/refs/tags/v0.1.8
+++ b/checkpoints/github.com/project-oak/git-ratchet/refs/tags/v0.1.8
@@ -1,4 +1,0 @@
-github.com/project-oak/git-ratchet refs/tags/v0.1.8
-3ef3b8ea2a95a072e9a2efc90e32d4bed7cccf73
-
-— github.com/project-oak/git-ratchet OfIP9ZwXX8ZQ3xPyLBGyjg+ucagm6xD5eR+wFMHlZT8JNcTl2Vm8+YUAB79SrnlIppHLuYEBWB736kaNZmoHU/2QwgQ=— github.com/BenBirt/git-witness yiiRJwAAAABqX22KdtyEdI5gbPtiR470y6Tp8H55ZKzPgUADKFtuGTCSA1g9dLfh/cYsUFHpyW5Y6Ui49aTrga7tHtEZOrGSTfi2DQ==

--- a/checkpoints/github.com/project-oak/git-ratchet/vkeys.txt
+++ b/checkpoints/github.com/project-oak/git-ratchet/vkeys.txt
@@ -1,1 +1,0 @@
-github.com/project-oak/git-ratchet+39f20ff5+AfIbFaum99YNfTOUk2R3eEj6OjOSGVaqH98I8UniqQKJ


### PR DESCRIPTION
git-ratchet's github-issue witnessing is now `tlog`-only, and its layout and wire format changed with it. This repository was still set up for the `git-checkpoint` scheme it replaced.

### Old state removed rather than migrated

The seven files under `checkpoints/github.com/project-oak/git-ratchet/` recorded per-ref `git-checkpoint` notes, which say nothing about a transparency log. A new log starts at size 0 and this witness ratchets from there, so there is nothing to carry across. They remain in this repository's history, which is where a witness's record belongs anyway.

It is also forced: `checkpoints/<origin>` has to be a *file* in the new layout, and it was a directory.

### Layout

```
origins/<origin>       trusted verifier keys, one per line   (was checkpoints/<origin>/vkeys.txt)
checkpoints/<origin>   the last cosigned checkpoint          (was checkpoints/<origin>/<ref>)
```

One log per monitored repository, so one state file per origin, and the ratchet is over the log's tree size rather than over any one ref.

### No origin is registered

The key that was here is for the scheme being left behind. Registering an origin again means adding its new verifier key at `origins/<origin>` — with the origin name the log actually uses. Until then every request is answered `404 Not Found` and no state is written.

### The workflow

Pinned to [`project-oak/git-ratchet@ef61689`](https://github.com/project-oak/git-ratchet/commit/ef61689a3df70e2d443b18ac56288931178c8ce7), the commit that merged the tlog tooling upstream.

It is a commit rather than `@main`: this witness runs the origin project's code, so which revision it runs should be a deliberate choice rather than whatever that project's branch says today. The previous pin to `@v0.1.7` had the same property. A tag would read better than a SHA once there is one covering this work.

Unchanged: the `issues: opened` trigger, the `checkpoint:` title guard, the concurrency group and the permissions. Titles are now `checkpoint: <origin>` with no ref, which the group keys on, so it serialises runs per log — the granularity the single state file needs.

### What this cannot verify

`actions/cosign` is the one part of the chain with no test anywhere; its first real exercise is the first checkpoint after this merges. Worth watching that run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PusRStktAvFcS16yy9VhVS)_