### PR TITLE
Pin to the key-format change

### DIFF
--- a/.github/workflows/cosign.yml
+++ b/.github/workflows/cosign.yml
@@ -14,7 +14,7 @@ jobs:
       group: cosign-${{ github.event.issue.title }}
       cancel-in-progress: false
     steps:
-      - uses: project-oak/git-ratchet/actions/cosign@ef61689a3df70e2d443b18ac56288931178c8ce7
+      - uses: project-oak/git-ratchet/actions/cosign@07aa8aa0318cf87afc7d69ff4aaf5da5a856585d
         with:
           witness-key: ${{ secrets.WITNESS_SIGNING_KEY }}
 


### PR DESCRIPTION
Bumps the `actions/cosign` pin from `ef61689` to `07aa8aa`, the commit that moved private keys to the [signed-note](https://c2sp.org/signed-note@v1.0.0) encoding. That commit is also what `v0.1.9` is tagged at, so the pinned Action and the released binary are the same code.

`WITNESS_SIGNING_KEY` must be re-encoded to match — the new binary rejects the old two-line vkey-and-seed form.

Note the timing does not depend on this PR: `actions/cosign` installs the binary from git-ratchet's **latest release**, so once `v0.1.9` publishes, witness runs pick up the new `cosign` whether or not this is merged. The secret is what needs to be in place, not the pin.